### PR TITLE
Canalize Ole32 calls during UIAutomation creation

### DIFF
--- a/src/main/java/mmarquee/automation/UIAutomation.java
+++ b/src/main/java/mmarquee/automation/UIAutomation.java
@@ -26,6 +26,7 @@ import mmarquee.automation.controls.AutomationWindow;
 import mmarquee.automation.controls.menu.AutomationMenu;
 import mmarquee.automation.pattern.PatternNotFoundException;
 import mmarquee.automation.uiautomation.*;
+import mmarquee.automation.utils.Canalizer;
 import mmarquee.automation.utils.Utils;
 
 import java.util.ArrayList;
@@ -42,6 +43,8 @@ public class UIAutomation extends BaseAutomation {
     protected Logger logger = Logger.getLogger(UIAutomation.class.getName());
 
     protected static UIAutomation INSTANCE = null;
+    private static final Ole32 CANALIZED_OLE32_INSTANCE = Canalizer.canalize(com.sun.jna.platform.win32.Ole32.INSTANCE);
+
 
     protected AutomationElement rootElement;
 
@@ -65,11 +68,11 @@ public class UIAutomation extends BaseAutomation {
      * Constructor for UIAutomation library
      */
     protected UIAutomation() {
-        Ole32.INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_APARTMENTTHREADED);
+        CANALIZED_OLE32_INSTANCE.CoInitializeEx(Pointer.NULL, Ole32.COINIT_APARTMENTTHREADED);
 
         PointerByReference pbr = new PointerByReference();
 
-        WinNT.HRESULT hr = Ole32.INSTANCE.CoCreateInstance(
+        WinNT.HRESULT hr = CANALIZED_OLE32_INSTANCE.CoCreateInstance(
                 IUIAutomation.CLSID,
                 null,
                 WTypes.CLSCTX_SERVER,

--- a/src/main/java/mmarquee/automation/utils/Canalizer.java
+++ b/src/main/java/mmarquee/automation/utils/Canalizer.java
@@ -1,0 +1,86 @@
+package mmarquee.automation.utils;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+/**
+ * Wraps an interface instance in a way that all calls to interface methods originate from the same thread
+ *
+ * @author Pascal Bihler
+ *
+ */
+public class Canalizer
+{
+    /** The thread where all calls originate from */
+    static final ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    /**
+     * Wraps an interface instance in a way that all calls to interface methods originate from the same thread
+     *
+     * @param <T> The type of the Object to canalize
+     * @param plainInstance The instance to canalize
+     * @return the canalized instance
+     */
+    @SuppressWarnings("unchecked")
+    public static <T extends Object> T canalize(final T plainInstance) {
+        final CanalizerInvocationHandler invocationHandler = new CanalizerInvocationHandler(executor,plainInstance);
+        return (T) java.lang.reflect.Proxy
+                .newProxyInstance(plainInstance.getClass().getClassLoader(),
+                        getInterfaces(plainInstance),
+                        invocationHandler);
+    }
+
+    private static Class<?>[] getInterfaces(final Object target) {
+        Class<?> base = target.getClass();
+        final Set<Class<?>> interfaces = new HashSet<>();
+        if (base.isInterface()) {
+            interfaces.add(base);
+        }
+        while (base != null && !Object.class.equals(base)) {
+            interfaces.addAll(Arrays.asList(base.getInterfaces()));
+            base = base.getSuperclass();
+        }
+        return interfaces.toArray(new Class[0]);
+    }
+
+    static class CanalizerInvocationHandler implements InvocationHandler {
+        private ExecutorService executor;
+        private Object underlying;
+
+        public CanalizerInvocationHandler(final ExecutorService executor, final Object underlying) {
+            this.executor = executor;
+            this.underlying = underlying;
+        }
+
+        @Override
+        public Object invoke(final Object proxy, final Method method, final Object[] args) throws Throwable
+        {
+            final Callable<Object> task = new Callable<Object>() {
+                @Override
+                public Object call() throws Exception
+                {
+                    return method.invoke(underlying, args);
+                }
+            };
+
+            final Future<Object> result = executor.submit(task);
+
+            try {
+                return result.get();
+            } catch (final ExecutionException ex) {
+                throw ex.getCause();
+            }
+        }
+
+    }
+
+}


### PR DESCRIPTION
Otherwise, the retained automation references might become invalid later on when using the Lib in a highly multi-threaded envirdonment