### PR TITLE
FIX(Make mvn compile library against Java 1.6)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,8 +139,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>1.6</source>
+          <target>1.6</target>
+          <testTarget>1.8</testTarget>
+          <testSource>1.8</testSource>
         </configuration>
         <version>2.3.2</version>
       </plugin>

--- a/src/main/java/mmarquee/automation/controls/AutomationTab.java
+++ b/src/main/java/mmarquee/automation/controls/AutomationTab.java
@@ -44,7 +44,7 @@ public class AutomationTab extends AutomationContainer {
      */
     public List<AutomationTabItem> getTabItems() throws PatternNotFoundException {
         // Now get the list of tab items
-        List<AutomationTabItem> tabItems = new ArrayList<>();
+        List<AutomationTabItem> tabItems = new ArrayList<AutomationTabItem>();
 
         try {
             List<AutomationElement> collection = this.findAll(new TreeScope(TreeScope.Descendants),this.createControlTypeCondition(ControlType.TabItem));

--- a/src/main/java/mmarquee/automation/utils/Canalizer.java
+++ b/src/main/java/mmarquee/automation/utils/Canalizer.java
@@ -54,7 +54,7 @@ public class Canalizer {
 
     private static Class<?>[] getInterfaces(final Object target) {
         Class<?> base = target.getClass();
-        final Set<Class<?>> interfaces = new HashSet<>();
+        final Set<Class<?>> interfaces = new HashSet<Class<?>>();
         if (base.isInterface()) {
             interfaces.add(base);
         }


### PR DESCRIPTION
Since no features of Java 7/8 are used (yet), we do not have to exclude
the folks which still (have to) use Java 6.