### PR TITLE
ENC(Made AutomationComboBox an AutomationContainer)

### DIFF
--- a/src/main/java/mmarquee/automation/controls/AutomationComboBox.java
+++ b/src/main/java/mmarquee/automation/controls/AutomationComboBox.java
@@ -36,7 +36,7 @@ import java.util.regex.Pattern;
  * Date 01/02/2016.
  */
 public final class AutomationComboBox
-        extends AutomationBase
+        extends AutomationContainer
         implements Expandable, Valueable, Focusable {
 
     /** The expand collapse pattern. */
@@ -266,7 +266,7 @@ public final class AutomationComboBox
             throw new ItemNotFoundException(automationId);
         }
     }
-    
+
     /**
      * Gets the current selection.
      * @return The current selection
@@ -279,13 +279,13 @@ public final class AutomationComboBox
         }
         if (this.selectionPattern != null) {
 	        List<AutomationElement> collection = this.selectionPattern.getCurrentSelection();
-	
+
 	        List<AutomationListItem> list = new ArrayList<>();
-	        
+
 	        for (AutomationElement element : collection) {
 	            list.add(new AutomationListItem(new ElementBuilder(element)));
 	        }
-	
+
 	        return list;
 	    }
         throw new PatternNotFoundException("Could not determine selection");


### PR DESCRIPTION
Since it often can have other Children than only ListElements - e.g. Buttons to expand (when the expand pattern fails - seen with WPF)