### PR TITLE
ENH(Made UIAutomation.getDesktopWindow() consistent with getDesktopWindows()

### DIFF
--- a/src/main/java/mmarquee/demo/DemoGrid.java
+++ b/src/main/java/mmarquee/demo/DemoGrid.java
@@ -50,7 +50,7 @@ public class DemoGrid extends TestBase {
         AutomationWindow applicationWindow = null;
 
         try {
-            applicationWindow = automation.getDesktopWindow("Main Form");
+            applicationWindow = automation.getDesktopWindow("Demo Form");
         } catch (Exception ex) {
             logger.info("Failed to find `Demo Form`");
         }

--- a/src/main/java/mmarquee/demo/TestMainWPF.java
+++ b/src/main/java/mmarquee/demo/TestMainWPF.java
@@ -591,7 +591,7 @@ public class TestMainWPF extends TestBase {
 
             // Same for desktop window
             try {
-                automation.getDesktopWindow("MainWindow99");
+                automation.getDesktopWindow("MainWindow99",2);
             } catch (AutomationException ex) {
                 logger.info("Failed to find `MainWindow99` - " + ex.getClass());
             }
@@ -600,7 +600,7 @@ public class TestMainWPF extends TestBase {
 
             // .. and object
             try {
-                automation.getDesktopWindow("MainWindow00");
+                automation.getDesktopObject("MainWindow00",2);
             } catch (AutomationException ex) {
                 logger.info("Failed to find `MainWindow00` - " + ex.getClass());
             }

--- a/src/test/java/mmarquee/automation/UIAutomationTest.java
+++ b/src/test/java/mmarquee/automation/UIAutomationTest.java
@@ -575,4 +575,29 @@ public class UIAutomationTest extends BaseAutomationTest {
         UIAutomation.getInstance().getDesktopWindow(Pattern.compile(".*Notepad99"));
     }
 
+    @Test
+    public void testGetWindow_succeeds() throws Exception {
+    	doTestWithNotepad((instance, app) -> {
+            AutomationWindow window = instance.getWindow(getLocal("notepad.title"));
+            assertNotNull(window);
+        });
+    }
+    
+    @Test(expected = ItemNotFoundException.class)
+    public void testGetWindow_Fails_When_Not_Window_Present() throws IOException, AutomationException, PatternNotFoundException {
+        UIAutomation.getInstance().getWindow("Untitled - Notepad99");
+    }
+
+    @Test
+    public void testGetWindow_WithRegexp_succeeds() throws Exception {
+    	doTestWithNotepad((instance, app) -> {
+            AutomationWindow window = instance.getWindow(Pattern.compile(Pattern.quote(getLocal("notepad.title"))));
+            assertNotNull(window);
+        });
+    }
+    
+    @Test(expected = ItemNotFoundException.class)
+    public void testGetWindow_WithRegexp_Fails_When_Not_Window_Present() throws IOException, AutomationException, PatternNotFoundException {
+        UIAutomation.getInstance().getWindow(Pattern.compile(".*Notepad99"));
+    }
 }


### PR DESCRIPTION
Now, UIAutomation.getDesktopWindow() only searches the top windows (direct
children of desktop), since the deep search before might lead to long
execution times on crowded desktops. The old behavior is now available
as "getWindow", similar to the existing AutomationWindow.getWindow().