### PR TITLE
Provide correct dependency scope for findbugs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>findbugs</artifactId>
           <version>3.0.1</version>
+          <scope>test</scope>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
The dependency for "findbugs" should be scoped to `test` - otherwise it blows up the "all inclusive" jar without need.